### PR TITLE
Append image name to SBOM artifact name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ runs:
     - name: Archive SBOM
       uses: actions/upload-artifact@v4
       with:
-        name: SBOM
+        name: SBOM-${{ inputs.image_name }}
         path: SBOM


### PR DESCRIPTION
**Problem**

Currently it is not possible to create and upload multiple SBOM artifacts from a single workflow run since the artifact name "SBOM" is hardcoded. With Monorepo deploying multiple apps from a single workflow using this GHA fails. 

**Solution Approach**

Add the image name to the artifact name.