### PR TITLE
chore(deps): upgrade to syft 1.44.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Install syft
       shell: bash
       run: |
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.0.1
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v1.44.0
 
     - name: Create SBOM
       shell: bash


### PR DESCRIPTION
should the bundled syft version potentially be communicated via the github action?